### PR TITLE
Feature/junit5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <junit.version>5.5.2</junit.version>
     </properties>
 
     <dependencies>
@@ -52,6 +54,13 @@
             <groupId>org.reactome.release</groupId>
             <artifactId>release-common-lib</artifactId>
             <version>1.2.0</version>
+            <exclusions>
+                <!-- ensures dependency on JUnit 4 is not forced by release-common-lib -->
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
@@ -61,9 +70,15 @@
 
         <!-- Test dependencies -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -76,6 +91,12 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>2.21.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>2.23.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -44,8 +44,6 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-
-        <junit.version>5.5.2</junit.version>
     </properties>
 
     <dependencies>
@@ -71,14 +69,8 @@
         <!-- Test dependencies -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <version>${junit.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit.version}</version>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.5.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/org/reactome/release/BioModelsUtilitiesTester.java
+++ b/src/test/java/org/reactome/release/BioModelsUtilitiesTester.java
@@ -2,20 +2,21 @@ package org.reactome.release;
 
 import org.gk.model.GKInstance;
 import org.gk.persistence.MySQLAdaptor;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import org.mockito.junit.MockitoJUnitRunner;
-
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class BioModelsUtilitiesTester {
 
     @Mock
@@ -43,5 +44,4 @@ public class BioModelsUtilitiesTester {
 
         assertThat(returnedDbInstance, is(nullValue()));
     }
-
 }

--- a/src/test/java/org/reactome/release/ModelsTSVParserTester.java
+++ b/src/test/java/org/reactome/release/ModelsTSVParserTester.java
@@ -1,9 +1,9 @@
 package org.reactome.release;
 
-import org.junit.Test;
-
 import java.nio.file.Paths;
 import java.util.*;
+
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;

--- a/src/test/resources/log4j2.xml
+++ b/src/test/resources/log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="info">
+<Appenders>
+	<Console name="Console" target="SYSTEM_OUT">
+		<PatternLayout pattern="%d{YYYY-MM-dd HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n" />
+	</Console>
+</Appenders>
+<Loggers>
+	<Root level="OFF">
+		<AppenderRef ref="Console" />
+	</Root>
+</Loggers>
+</Configuration>


### PR DESCRIPTION
Updates unit testing to use JUnit 5 and adds a log4j configuration to disable logging for unit tests.

All tests passed and had no logging output when running `mvn clean test` locally.